### PR TITLE
fix(tauri): allow ipc invocation of run_scan

### DIFF
--- a/Scanvas/src-tauri/capabilities/default.json
+++ b/Scanvas/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    { "identifier": "ipc:allow-run_scan" }
   ]
 }


### PR DESCRIPTION
The network graph was not displayed because the frontend was blocked from calling the `run_scan` command in the backend.

This change modifies the Tauri capabilities configuration to explicitly grant permission for this IPC call, allowing the frontend to fetch graph data from the backend.